### PR TITLE
Boost popup fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+pnpm-lock.yaml

--- a/app.js
+++ b/app.js
@@ -1,15 +1,21 @@
-const express = require("express");
-const path = require('path');
-const bodyParser = require("body-parser");
-const SteamAuth = require("node-steam-openid");
-const session = require('express-session');
-const sqlite3 = require('sqlite3').verbose();
-const SteamID = require('steamid');
+import express from "express";
+import path from "path";
+import bodyParser from "body-parser";
+import SteamAuth from "node-steam-openid";
+import session from "express-session";
+import sqlite3 from "sqlite3";
+import SteamID from "steamid";
+import { renderFile } from "ejs";
+import { fileURLToPath } from 'url';
+import moment from "moment";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(express.json());
 
-app.engine('html', require('ejs').renderFile);
+app.engine('html', renderFile);
 app.set('view engine', 'ejs');
 
 app.use(express.static(path.join(__dirname, 'views')));
@@ -153,8 +159,6 @@ app.post('/postContent', async (req, res) => {
         });
     });
 });
-
-const moment = require('moment');
 
 app.get('/forums', (req, res) => {
     const user = req.session.user;

--- a/app.js
+++ b/app.js
@@ -1,13 +1,14 @@
-import express from "express";
-import path from "path";
-import bodyParser from "body-parser";
-import SteamAuth from "node-steam-openid";
-import session from "express-session";
-import sqlite3 from "sqlite3";
-import SteamID from "steamid";
-import { renderFile } from "ejs";
+import express from 'express';
+import path from 'path';
+import bodyParser from 'body-parser';
+import SteamAuth from 'node-steam-openid';
+import session from 'express-session';
+import sqlite3 from 'sqlite3';
+// NOTE: Should SteamID be used somewhere?
+//import SteamID from "steamid";
+import { renderFile } from 'ejs';
 import { fileURLToPath } from 'url';
-import moment from "moment";
+import moment from 'moment';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -76,8 +77,7 @@ const db = new sqlite3.Database('users.db', sqlite3.OPEN_READWRITE, async (err) 
                     FROM moderators
                     JOIN users ON moderators.user_id = users.id`, [], (err, moderators) => {
         if (err) {
-            console.error("Error querying database: " + err.message);
-            return res.status(500).send("Internal Server Error");
+            console.error('Error querying database: ' + err.message);
         }
         const match = moderators.some(moderator => moderatorIds.includes(moderator.steam_id));
 
@@ -90,7 +90,7 @@ const db = new sqlite3.Database('users.db', sqlite3.OPEN_READWRITE, async (err) 
 
 // 3 posts per hour, 30 replies
 const MAX_POSTS = 3;
-const MAX_REPLIES = 30;
+
 // 1 hour
 const REFRESH_PERIOD = 3600000;
 
@@ -161,7 +161,6 @@ app.post('/postContent', async (req, res) => {
 });
 
 app.get('/forums', (req, res) => {
-    const user = req.session.user;
     const session = req.session;
 
     const sql = `SELECT threads.id as thread_id, threads.*, users.steam_username, users.steam_id, users.steam_avatar 
@@ -189,9 +188,8 @@ app.get('/forums', (req, res) => {
                 FROM moderators
                 JOIN users ON moderators.user_id = users.id`, [], (err, moderators) => {
             if (err) {
-                s
-                console.error("Error querying database: " + err.message);
-                return res.status(500).send("Internal Server Error");
+                console.error('Error querying database: ' + err.message);
+                return res.status(500).send('Internal Server Error');
             }
 
             res.render('forums', { forums: forums, session: session, moderators: moderators });
@@ -278,7 +276,7 @@ app.post('/remove_post', (req, res) => {
         return res.status(403).send('Unauthorized');
     }
 
-    const sqlCheckPost = `SELECT * FROM threads WHERE id = ?`;
+    const sqlCheckPost = 'SELECT * FROM threads WHERE id = ?';
     db.get(sqlCheckPost, [postId], (err, post) => {
         if (err) {
             console.error(err.message);
@@ -289,7 +287,7 @@ app.post('/remove_post', (req, res) => {
             return res.status(404).send('Post not found.');
         }
 
-        const sqlDeletePost = `DELETE FROM threads WHERE id = ?`;
+        const sqlDeletePost = 'DELETE FROM threads WHERE id = ?';
         db.run(sqlDeletePost, [postId], (err) => {
             if (err) {
                 console.error(err.message);
@@ -314,7 +312,7 @@ app.post('/remove_reply', (req, res) => {
         return res.status(403).send('Unauthorized');
     }
 
-    const sqlCheckPost = `SELECT * FROM posts WHERE id = ?`;
+    const sqlCheckPost = 'SELECT * FROM posts WHERE id = ?';
     db.get(sqlCheckPost, [replyId], (err, post) => {
         if (err) {
             console.error(err.message);
@@ -325,16 +323,16 @@ app.post('/remove_reply', (req, res) => {
             return res.status(404).send('Post not found.');
         }
 
-        const sqlDeletePost = `DELETE FROM posts WHERE id = ?`;
-        console.log("3")
+        const sqlDeletePost = 'DELETE FROM posts WHERE id = ?';
+        console.log('3')
         db.run(sqlDeletePost, [replyId], (err) => {
-            console.log("4")
+            console.log('4')
             if (err) {
-                console.log("5")
+                console.log('5')
                 console.error(err.message);
                 return res.status(500).send('Failed to delete post.');
             }
-            console.log("6")
+            console.log('6')
             return res.redirect('/post/' + post.thread);
         });
     });
@@ -349,8 +347,8 @@ const eloDb = new sqlite3.Database('sourcemod-local.sq3', (err) => {
 app.get('/', (req, res) => {
     eloDb.all('SELECT * FROM mgemod_stats ORDER BY rating DESC', [], (err, rows) => {
         if (err) {
-            console.error("Error querying database: " + err.message);
-            res.status(500).send("Internal Server Error");
+            console.error('Error querying database: ' + err.message);
+            res.status(500).send('Internal Server Error');
         } else {
             res.render('index', { session: req.session, elo: rows });
         }
@@ -380,18 +378,18 @@ app.get('/verify', async (req, res) => {
         // check if first time login
         db.get('SELECT * FROM users WHERE steam_id = ?', [user.steamid], (err, row) => {
             if (err) {
-                console.error("Error querying database: " + err.message);
+                console.error('Error querying database: ' + err.message);
             } else if (!row) {
                 // add if first time
                 db.run('INSERT INTO users (steam_id, steam_username, steam_avatar) VALUES (?, ?, ?)', [user.steamid, user.username, user.avatar.small], (err) => {
                     if (err) {
-                        console.error("Error inserting into database: " + err.message);
+                        console.error('Error inserting into database: ' + err.message);
                     }
                 });
             }
         });
     } catch (err) {
-        console.error("Authentication error: " + err.message);
+        console.error('Authentication error: ' + err.message);
     }
     return res.redirect('/');
 });
@@ -400,8 +398,8 @@ app.get('/player_page/:steamid', (req, res) => {
     const steamid = req.params.steamid;
     db.get('SELECT * FROM users WHERE steam_id = ?', [steamid], (err, row) => {
         if (err) {
-            console.error("Error querying database: " + err.message);
-            res.status(500).send("Internal Server Error");
+            console.error('Error querying database: ' + err.message);
+            res.status(500).send('Internal Server Error');
         } else if (!row) {
             const name = req.query.name;
             res.render('empty_player_page', { steamid, name });
@@ -417,8 +415,8 @@ app.get('/post/:forumid', (req, res) => {
 
     db.get('SELECT threads.id as thread_id, * FROM threads LEFT JOIN users ON threads.owner = users.id WHERE threads.id = ?', [forumid], (err, row) => {
         if (err) {
-            console.error("Error querying database: " + err.message);
-            return res.status(500).send("Internal Server Error");
+            console.error('Error querying database: ' + err.message);
+            return res.status(500).send('Internal Server Error');
         }
 
         db.all(`SELECT posts.*, users.steam_username, users.steam_id, users.steam_avatar
@@ -426,16 +424,16 @@ app.get('/post/:forumid', (req, res) => {
             posts.owner = users.id WHERE thread = ?`, [forumid], (err, posts) => {
 
             if (err) {
-                console.error("Error querying database: " + err.message);
-                return res.status(500).send("Internal Server Error");
+                console.error('Error querying database: ' + err.message);
+                return res.status(500).send('Internal Server Error');
             }
 
             db.all(`SELECT users.*, moderators.id as moderator_id
                     FROM moderators
                     JOIN users ON moderators.user_id = users.id`, [], (err, moderators) => {
                 if (err) {
-                    console.error("Error querying database: " + err.message);
-                    return res.status(500).send("Internal Server Error");
+                    console.error('Error querying database: ' + err.message);
+                    return res.status(500).send('Internal Server Error');
                 }
 
                 res.render('posts', { session: session, moderators: moderators, posts: posts, thread: row });
@@ -447,8 +445,8 @@ app.get('/post/:forumid', (req, res) => {
 app.get('/users', (req, res) => {
     db.all('SELECT * FROM users', [], (err, users) => {
         if (err) {
-            console.error("Error querying database: " + err.message);
-            res.status(500).send("Internal Server Error");
+            console.error('Error querying database: ' + err.message);
+            res.status(500).send('Internal Server Error');
             return;
         }
 
@@ -456,8 +454,8 @@ app.get('/users', (req, res) => {
             FROM moderators
             JOIN users ON moderators.user_id = users.id`, [], (err, moderators) => {
             if (err) {
-                console.error("Error querying database: " + err.message);
-                res.status(500).send("Internal Server Error");
+                console.error('Error querying database: ' + err.message);
+                res.status(500).send('Internal Server Error');
                 return;
             }
 
@@ -473,8 +471,8 @@ app.get('/load', (req, res) => {
     if (page === 'main') {
         eloDb.all('SELECT * FROM mgemod_stats ORDER BY rating DESC', [], (err, rows) => {
             if (err) {
-                console.error("Error querying database: " + err.message);
-                res.status(500).send("Internal Server Error");
+                console.error('Error querying database: ' + err.message);
+                res.status(500).send('Internal Server Error');
             } else {
                 return res.render('main', { elo: rows });
             }
@@ -487,7 +485,7 @@ app.get('/load', (req, res) => {
 app.get('/logout', (req, res) => {
     req.session.destroy(err => {
         if (err) {
-            console.error("Error destroying session: " + err.message);
+            console.error('Error destroying session: ' + err.message);
         }
         res.redirect('/');
     });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,18 @@
+import globals from 'globals';
+import pluginJs from '@eslint/js';
+
+
+export default [
+  { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
+  pluginJs.configs.recommended,
+  {
+    rules: {
+      'space-before-function-paren': ['error', {
+        'anonymous': 'never',
+        'named': 'never',
+        'asyncArrow': 'always'
+      }],
+      'quotes': ['error', 'single', { 'avoidEscape': true }],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "node-steam-openid": "^1.2.3",
         "sqlite3": "^5.1.7",
         "steamid": "^2.0.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.3.2"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2063,6 +2066,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/promise-inflight": {

--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
     "node-steam-openid": "^1.2.3",
     "sqlite3": "^5.1.7",
     "steamid": "^2.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.5.0",
+    "eslint": "9.x",
+    "globals": "^15.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "mge.tf",
   "version": "1.0.0",
   "description": "Website for mge.tf",
+  "type": "module",
   "main": "app.js",
   "scripts": {
-    "start": "node -r esm app.js",
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/views/forums.ejs
+++ b/views/forums.ejs
@@ -1,32 +1,39 @@
 <div>
-    <link rel="stylesheet" href="css/header.css"/>
-    <link rel="stylesheet" href="css/forums.css"/>
+    <link rel="stylesheet" href="css/header.css" />
+    <link rel="stylesheet" href="css/forums.css" />
     <div class="background-page"></div>
     <h1 class="description">Forum Posts</h1>
-    <div class="forum-posts">
-        <button class="create_post" hx-get="/load?page=create_post" hx-swap="outerHTML">Create Thread</button>
-        
-        <% forums.forEach(forum => { %>
-            <a class="forum-strip" hx-get="/post/<%= forum.thread_id %>" hx-target="#main" hx-swap="innerHTML">
+    <div hx-boost="true" class="forum-posts">
+        <button class="create_post" href="/load?page=create_post" hx-swap="outerHTML">Create Thread</button>
+
+        <% forums.forEach(forum=> { %>
+            <a class="forum-strip" href="/post/<%= forum.thread_id %>" hx-target="#main" hx-swap="innerHTML">
                 <ul>
-                    <p class="steam-username"><%= forum.steam_username + ' published at ' + forum.formatted_date %></p>
-                    <p class="title"><%= forum.title %></p>
-                    <p class="content"><%= forum.content %></p>
-        
+                    <p class="steam-username">
+                        <%= forum.steam_username + ' published at ' + forum.formatted_date %>
+                    </p>
+                    <p class="title">
+                        <%= forum.title %>
+                    </p>
+                    <p class="content">
+                        <%= forum.content %>
+                    </p>
+
                     <% if (session.user) { %>
-                        <% const isOwner = forum.steam_id === session.user.steamid; %>
-                        <% const isModerator = moderators.some(moderator => moderator.steam_id === session.user.steamid); %>
-                        <% if (isOwner || isModerator) { %>
-                            <form hx-post="/remove_post" hx-target="#main" hx-swap="innerHTML">
-                                <input type="hidden" name="post_id" value="<%= forum.thread_id %>">
-                                <input type="hidden" name="is_owner" value="<%= isOwner %>">
-                                <input type="hidden" name="is_moderator" value="<%= isModerator %>">
-                                <button class="remove-post" type="submit">Remove Post</button>
-                            </form>
-                        <% } %>
-                    <% } %>
+                        <% const isOwner=forum.steam_id===session.user.steamid; %>
+                            <% const isModerator=moderators.some(moderator=> moderator.steam_id ===
+                                session.user.steamid); %>
+                                <% if (isOwner || isModerator) { %>
+                                    <form hx-post="/remove_post" hx-target="#main" hx-swap="innerHTML">
+                                        <input type="hidden" name="post_id" value="<%= forum.thread_id %>">
+                                        <input type="hidden" name="is_owner" value="<%= isOwner %>">
+                                        <input type="hidden" name="is_moderator" value="<%= isModerator %>">
+                                        <button class="remove-post" type="submit">Remove Post</button>
+                                    </form>
+                                    <% } %>
+                                        <% } %>
                 </ul>
             </a>
-        <% }); %>
+            <% }); %>
     </div>
 </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,105 +1,116 @@
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <link rel="stylesheet" href="css/index.css"/>
-        <link rel="stylesheet" href="css/header.css"/>
+<!DOCTYPE html>
+<html lang="en">
 
-        <script src="/js/script.js" defer></script>
-        <script src="https://unpkg.com/htmx.org@1.9.12"></script>
-    </head>
-    <body>
-        <div class="sidebar-trigger" id="sidebar-trigger">
-            <!-- <img src="images/sidebar-logo.png" alt="Sidebar Logo" class="sidebar-logo"> -->
-            _____
-            _____
-            _____
+<head>
+    <link rel="stylesheet" href="css/index.css" />
+    <link rel="stylesheet" href="css/header.css" />
+
+    <script src="/js/script.js" defer></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+</head>
+
+<body>
+    <div class="sidebar-trigger" id="sidebar-trigger">
+        <!-- <img src="images/sidebar-logo.png" alt="Sidebar Logo" class="sidebar-logo"> -->
+        _____
+        _____
+        _____
+    </div>
+    <header class="overlay">
+        <div hx-boost="true" class="top-section">
+            <h1 class="title"><a href="/load?page=main" hx-swap="innerHtml" hx-target="#main"
+                    class="title-link">mge.tf</a></h1>
+            <img class="logo" src="">
         </div>
-        <header class="overlay">
-            <div class="top-section">
-                <h1 class="title"><a hx-get="/load?page=main" hx-swap="innerHtml" hx-target="#main" class="title-link">mge.tf</a></h1>
-                <img class="logo" src="">
-            </div>
-            <div class="bottom-section">
-                <div class="menu">
-                    <a class="menu-button" hx-get="/load?page=main" hx-target="#main" hx-swap="innerHtml">Home</a>
-                    <a class="menu-button" hx-get="/users" hx-target="#main" hx-swap="innerHtml">Users</a>
-                    <div class="dropdown">
-                        <a class="menu-button dropdown" hx-get="/load?page=league" hx-target="#main" hx-swap="innerHtml">League ▶</a>
-                        <div class="dropdown-content">
-                            <a class="dropdown-option" hx-get="/load?page=league" hx-target="#main" hx-swap="innerHtml">League Home</a>
-                            <a class="dropdown-option" hx-get="/load?page=signup" hx-target="#main" hx-swap="innerHtml">Signups</a>
-                            <a class="dropdown-option" hx-get="/load?page=rules"  hx-target="#main" hx-swap="innerHTML">Rules</a>
-                        </div>
+        <div class="bottom-section">
+            <div hx-boost="true" class="menu">
+                <a class="menu-button" href="/load?page=main" hx-target="#main" hx-swap="innerHtml">Home</a>
+                <a class="menu-button" href="/users" hx-target="#main" hx-swap="innerHtml">Users</a>
+                <div class="dropdown">
+                    <a class="menu-button dropdown" href="/load?page=league" hx-target="#main"
+                        hx-swap="innerHtml">League ▶</a>
+                    <div class="dropdown-content">
+                        <a class="dropdown-option" href="/load?page=league" hx-target="#main" hx-swap="innerHtml">League
+                            Home</a>
+                        <a class="dropdown-option" href="/load?page=signup" hx-target="#main"
+                            hx-swap="innerHtml">Signups</a>
+                        <a class="dropdown-option" href="/load?page=rules" hx-target="#main"
+                            hx-swap="innerHTML">Rules</a>
                     </div>
-                    <div class="dropdown">
-                        <a class="menu-button dropdown" hx-get="/load?page=seasons" hx-target="#main" hx-swap="innerHtml">Seasons ▶</a>
-                        <div class="dropdown-content">
-                            <a class="dropdown-option" hx-get="/load?page=season1" hx-target="#main" hx-swap="innerHtml">Season 1</a>
-                        </div>
-                    </div>                
-                    <a class="menu-button" hx-get="/load?page=coaching" hx-target="#main" hx-swap="innerHtml">Coaching</a>
-                    <a class="menu-button forum-button" hx-get="/forums" hx-swap="innerHtml" hx-target="#main">Forums</a>
                 </div>
+                <div class="dropdown">
+                    <a class="menu-button dropdown" href="/load?page=seasons" hx-target="#main"
+                        hx-swap="innerHtml">Seasons ▶</a>
+                    <div class="dropdown-content">
+                        <a class="dropdown-option" href="/load?page=season1" hx-target="#main"
+                            hx-swap="innerHtml">Season 1</a>
+                    </div>
+                </div>
+                <a class="menu-button" href="/load?page=coaching" hx-target="#main" hx-swap="innerHtml">Coaching</a>
+                <a class="menu-button forum-button" href="/forums" hx-swap="innerHtml" hx-target="#main">Forums</a>
             </div>
-        </header>
-        <div class="strip">
-            <div class="connectinfo">
-                Server IP: connect mge.tf
-                <a href="steam://connect/45.76.26.238:27015" class="join-server">connect</a>
-            </div>
-            <div class="discord-section">
-                <a class="discordinfo">Join the discord </a>
-                <a class="join-discord" id="discordInvite" href="https://discord.gg/j6kDYSpYbs">discord.gg</a>
-            </div>
-            <div class="signin-section">
-                <% if (!session.user) { %>
+        </div>
+    </header>
+    <div class="strip">
+        <div class="connectinfo">
+            Server IP: connect mge.tf
+            <a href="steam://connect/45.76.26.238:27015" class="join-server">connect</a>
+        </div>
+        <div class="discord-section">
+            <a class="discordinfo">Join the discord </a>
+            <a class="join-discord" id="discordInvite" href="https://discord.gg/j6kDYSpYbs">discord.gg</a>
+        </div>
+        <div hx-boost="true" class="signin-section">
+            <% if (!session.user) { %>
                 <a class="signin-button" href="/init-openid">
                     <img class="steam-login-logo" src="../images/signin-thru-steam.png" alt="Steam Logo">
                 </a>
                 <% } else { %>
-                <a class="profile-container" hx-target="#main" hx-swap="innerHtml" hx-get="/player_page/<%= session.user.steamid %>">
-                    <img class="profile-pic" src="<%= session.user.avatar.small %>" alt="Avatar">
-                    <% 
-                        const maxLength = 15;
-                        let displayName = session.user.username;
-                        if (displayName.length > maxLength) {
+                    <a class="profile-container" hx-target="#main" hx-swap="innerHtml"
+                        href="/player_page/<%= session.user.steamid %>">
+                        <img class="profile-pic" src="<%= session.user.avatar.small %>" alt="Avatar">
+                        <% const maxLength=15; let displayName=session.user.username; if (displayName.length> maxLength)
+                            {
                             displayName = displayName.slice(0, maxLength) + '...';
-                        }
-                    %>
-                    <span class="logged-in-username"><%= displayName %></span>
-                </a>
-                <% } %>
-            </div>
-        </div>     
-        
-        <div class="tournament-hover-button">News ▶</div>
+                            }
+                            %>
+                            <span class="logged-in-username">
+                                <%= displayName %>
+                            </span>
+                    </a>
+                    <% } %>
+        </div>
+    </div>
 
-        <div class="tournaments-overlay">
-            <div class="tourney-section">
-                <h3 class="tourney-title">UPCOMING</h3>
-                <div class="tournament-scroll">
-                    <div class="button-container">
-                        <a class="tourney_button" href="article001.php">2v2 Cup (July 27/28)</a>
-                        <a class="tourney_button" href="article002.php">1v1 Cup (August 3)</a>
-                        <a class="tourney_button" href="signup.php">Season 1 Signup (August 10)</a>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="tourney-section">
-                <h3 class="tourney-title">COMPLETED</h3>
-                <div class="tournament-scroll">
-                    <div class="button-container">
-                        <a class="tourney_button" id="cup3Button">2v2 CUP 3 Main Event (5/05/24)</a>
-                        <a class="tourney_button" id="cup3Button">2v2 CUP 3 Qualifier (5/04/24)</a>
-                        <a class="tourney_button" id="cup2Button">2v2 CUP 2 Results (1/28/24)</a>
-                        <a class="tourney_button" id="cup1Button">2v2 CUP 1 Results (11/19/23)</a>
-                    </div>
+    <div class="tournament-hover-button">News ▶</div>
+
+    <div class="tournaments-overlay">
+        <div class="tourney-section">
+            <h3 class="tourney-title">UPCOMING</h3>
+            <div class="tournament-scroll">
+                <div class="button-container">
+                    <a class="tourney_button" href="article001.php">2v2 Cup (July 27/28)</a>
+                    <a class="tourney_button" href="article002.php">1v1 Cup (August 3)</a>
+                    <a class="tourney_button" href="signup.php">Season 1 Signup (August 10)</a>
                 </div>
             </div>
         </div>
-        <div id="main">
-            <%- include('main', {elo: elo}) %>
+
+        <div class="tourney-section">
+            <h3 class="tourney-title">COMPLETED</h3>
+            <div class="tournament-scroll">
+                <div class="button-container">
+                    <a class="tourney_button" id="cup3Button">2v2 CUP 3 Main Event (5/05/24)</a>
+                    <a class="tourney_button" id="cup3Button">2v2 CUP 3 Qualifier (5/04/24)</a>
+                    <a class="tourney_button" id="cup2Button">2v2 CUP 2 Results (1/28/24)</a>
+                    <a class="tourney_button" id="cup1Button">2v2 CUP 1 Results (11/19/23)</a>
+                </div>
+            </div>
         </div>
-    </body>
-    </html>
+    </div>
+    <div id="main">
+        <%- include('main', {elo: elo}) %>
+    </div>
+</body>
+
+</html>

--- a/views/js/script.js
+++ b/views/js/script.js
@@ -1,5 +1,4 @@
-document.addEventListener("DOMContentLoaded", function() {
-
+document.addEventListener('DOMContentLoaded', function() {
     const sidebarTrigger = document.querySelector('.sidebar-trigger');
     const overlay = document.querySelector('.overlay');
     const tournamentTrigger = document.querySelector('.tournament-hover-button');
@@ -32,32 +31,38 @@ document.addEventListener("DOMContentLoaded", function() {
         tournamentTrigger.style.opacity = '0';
     });
 
-    document.getElementById("cup3Button").addEventListener("click", function() {
-        openInNewTab('https://brackethq.com/b/6lk1b/');
+    document.getElementById('cup3Button').addEventListener('click', function() {
+        window.open('https://brackethq.com/b/6lk1b/');
     });
-    document.getElementById("cup2Button").addEventListener("click", function() {
-        openInNewTab('https://brackethq.com/b/8lovb/');
+    document.getElementById('cup2Button').addEventListener('click', function() {
+        window.open('https://brackethq.com/b/8lovb/');
     });
-    document.getElementById("cup1Button").addEventListener("click", function() {
-        openInNewTab('https://brackethq.com/b/5qorb/');
+    document.getElementById('cup1Button').addEventListener('click', function() {
+        window.open('https://brackethq.com/b/5qorb/');
     });
-    document.getElementById("new1Button").addEventListener("click", function() {
-        openInNewTab('https://university.com');
+    document.getElementById('new1Button').addEventListener('click', function() {
+        window.open('https://university.com');
     });
-    document.getElementById("new2Button").addEventListener("click", function() {
-        openInNewTab('https://university.com');
+    document.getElementById('new2Button').addEventListener('click', function() {
+        window.open('https://university.com');
     });
-    document.getElementById("discordInvite").addEventListener("click", function() {
-        openInNewTab('discord.gg/j6kDYSpYbs');
-    });
+    document
+        .getElementById('discordInvite')
+        .addEventListener('click', function() {
+            window.open('discord.gg/j6kDYSpYbs');
+        });
 });
 
 document.addEventListener('DOMContentLoaded', () => {
+    let seen = localStorage.getItem('popupSeen');
     const announcementOverlay = document.getElementById('announcement-overlay');
     const closeButton = document.getElementById('closeOverlay');
-  
-    announcementOverlay.style.display = 'block';
-  
+
+    if (!seen) {
+        announcementOverlay.style.display = 'block';
+        localStorage.setItem('popupSeen', 'true');
+    }
+
     closeButton.addEventListener('click', function() {
         announcementOverlay.style.display = 'none';
     });

--- a/views/js/users.js
+++ b/views/js/users.js
@@ -10,14 +10,14 @@ function filterUsers() {
         steamId = users[i].getElementsByClassName('users_steam_id')[0];
         usernameTxt = username.textContent || username.innerText;
         steamIdTxt = steamId.textContent || steamId.innerText;
-        
+
         if (usernameTxt.toLowerCase().indexOf(filter) > -1 || steamIdTxt.indexOf(filter) > -1) {
-            users[i].style.display = "";
+            users[i].style.display = '';
         } else {
-            users[i].style.display = "none";
+            users[i].style.display = 'none';
         }
     }
 }
-document.getElementById("userSearch").addEventListener("input", function() {
+document.getElementById('userSearch').addEventListener('input', function() {
     filterUsers();
 });

--- a/views/main.ejs
+++ b/views/main.ejs
@@ -16,15 +16,26 @@
                 </tr>
             </thead>
             <tbody id="eloTableBody">
-                <% elo.forEach((player, index) => { %>
-                    <tr style="cursor:pointer" hx-target="#main" hx-get=<%= "/player_page/" + player.steamid + "?name=" + player.name %> class="elo-row">
-                        <td><%= index + 1 %></td>
-                        <td class="name-column"><%= player.name %></a></td>
-                        <td><%= player.rating %></td>
-                        <td><%= player.wins %></td>
-                        <td><%= player.losses %></td>
+                <% elo.forEach((player, index)=> { %>
+                    <tr style="cursor:pointer" hx-target="#main" hx-get=<%="/player_page/" + player.steamid + "?name=" +
+                        player.name %> class="elo-row">
+                        <td>
+                            <%= index + 1 %>
+                        </td>
+                        <td class="name-column">
+                            <%= player.name %></a>
+                        </td>
+                        <td>
+                            <%= player.rating %>
+                        </td>
+                        <td>
+                            <%= player.wins %>
+                        </td>
+                        <td>
+                            <%= player.losses %>
+                        </td>
                     </tr>
-                <% }) %>
+                    <% }) %>
             </tbody>
         </table>
     </div>
@@ -36,10 +47,10 @@
             <a class="main-menu-button main-2" hx-get="/load?page=seasons" hx-target="#main" hx-swap="innerHtml">Seasons</a>
             <a class="main-menu-button main-4" hx-get="/forums" hx-swap="innerHtml" hx-target="#main">Forums</a>
         </div> -->
-        
-        <div class="main-menu-1v1-2v2">
-            <a class="mm-1v1" hx-get="/load?page=1v1signup" hx-target="#main" hx-swap="innerHtml">1v1</a>
-            <a class="mm-2v2" hx-get="/load?page=2v2signup" hx-target="#main" hx-swap="innerHtml">2v2</a>
+
+        <div hx-boost="true" class="main-menu-1v1-2v2">
+            <a class="mm-1v1" href="/load?page=1v1signup" hx-target="#main" hx-swap="innerHtml">1v1</a>
+            <a class="mm-2v2" href="/load?page=2v2signup" hx-target="#main" hx-swap="innerHtml">2v2</a>
         </div>
     </div>
     <!-- <div class="main-connect-info">Official TF2 MGE Server: 'connect mge.tf'

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -1,9 +1,9 @@
 <h1 class="description">CHOOSE ONE</h1>
 <div class="background-page"></div>
 
-<link rel="stylesheet" href="css/signup.css"/>
+<link rel="stylesheet" href="css/signup.css" />
 
-<div class="signup-button-container">
-    <a class="custom-button button-blue" hx-get="/load?page=1v1signup.ejs" hx-swap="innerHtml" hx-target="#main">1v1</a>
-    <a class="custom-button button-red" hx-get="/load?page=2v2signup.ejs" hx-swap="innerHtml" hx-target="#main">2v2</a>
+<div hx-boost="true" class="signup-button-container">
+    <a class="custom-button button-blue" href="/load?page=1v1signup.ejs" hx-swap="innerHtml" hx-target="#main">1v1</a>
+    <a class="custom-button button-red" href="/load?page=2v2signup.ejs" hx-swap="innerHtml" hx-target="#main">2v2</a>
 </div>W


### PR DESCRIPTION
A few changes in the commit:

- Swapped the project from using commonJS to using the more modern ESM module syntax. (i.e., no more "require" shenanigans, also works in browsers now so functionality can be written in node and shipped to the browser)
- Added ESLint + config for both static analysis + some formatting consistency. (If you're on VSCode you can set it to automatically format the file according to ESLint rules on save.) 
- Switched the anchor tags to href and set the parents to hx-boost which should allow for forward/backward navigation while also providing a fallback to no-JS browsers.
- Added local storage caching for the pop-up that shows up every time you navigate to the home page. It's been set to show the pop-up once when someone visits the site, and then it won't show up again unless they clear their cache. 

The last one is debatable, I'm not sure if you want the pop-up to be the main thing that alerts people to upcoming tournaments, maybe we can just make a more eye-catching section on the main page for news like that?
