### PR TITLE
fix: add middleware to redirect to root to prevent layout issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 pnpm-lock.yaml
+logs/*

--- a/app.js
+++ b/app.js
@@ -28,6 +28,13 @@ app.use(session({
     resave: false,
     saveUninitialized: true
 }));
+
+app.use((req, res, next) => {
+    if (req.url !== '/' && req.headers['hx-request'] !== 'true') {
+        return res.redirect('/');
+    }
+    next();
+});
 // user database
 const db = new sqlite3.Database('users.db', sqlite3.OPEN_READWRITE, async (err) => {
     if (err) {

--- a/helpers/logger.js
+++ b/helpers/logger.js
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+
+export function logRequestToFile(req, filename) {
+    const reqData = {
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      query: req.query,
+      params: req.params,
+      body: req.body,
+      ip: req.ip,
+      protocol: req.protocol,
+      httpVersion: req.httpVersion,
+      originalUrl: req.originalUrl,
+      baseUrl: req.baseUrl,
+      path: req.path
+  };
+
+  const reqDataStr = JSON.stringify(reqData, null, 2);
+
+  fs.writeFile(filename, reqDataStr, err => {
+    if (err) {
+      console.log('Error writing to file: ' + filename);
+      console.error(err);
+    } 
+  });
+}
+
+export function appendRequestToFile(req, filename) {
+    const reqData = {
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      query: req.query,
+      params: req.params,
+      body: req.body,
+      ip: req.ip,
+      protocol: req.protocol,
+      httpVersion: req.httpVersion,
+      originalUrl: req.originalUrl,
+      baseUrl: req.baseUrl,
+      path: req.path
+  };
+
+  const reqDataStr = JSON.stringify(reqData, null, 2);
+  fs.appendFile(filename, reqDataStr, err => {
+    console.error(err);
+  })
+}
+


### PR DESCRIPTION
Intercept the requests with a check to see if it was triggered by htmx or if it was a regular navigation, if it's a regular navigation, i.e., someone types in mge.tf/users, it will redirect them to the home page to preserve styling.

Using back/forward navigation *should* still work, though. 